### PR TITLE
show version with -h option

### DIFF
--- a/bin/f5_monitor
+++ b/bin/f5_monitor
@@ -26,8 +26,7 @@ EOF
   end
 
   opts.on("-h", "--help") do
-    spec = Gem::Specification::load(File.expand_path("../../newrelic_f5_plugin.gemspec", __FILE__))
-    puts "New Relic F5 Plugin version #{spec.version}"
+    puts "New Relic F5 Plugin version #{NewRelic::F5Plugin::VERSION}"
     puts opts
     if File.basename($0) == File.basename(__FILE__)
       exit 0


### PR DESCRIPTION
Hi, 

I found it would be useful to tell which version it is from command line so I add this.

[vagrant@centos58 ~]$ f5_monitor -h
New Relic F5 Plugin version 1.0.7
Usage:
  f5_monitor  ( run | install ) [options]
    -v, --verbose                    Run verbosely
    -l, --license LICENSE_KEY        Your NewRelic account License Key
    -c, --config FILE                Override the location of the newrelic_plugin.yml
    -h, --help
