### PR TITLE
Adding logging instructions to README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -75,7 +75,7 @@ SNMP version 2c is supported.
       f5_monitor install -l LICENSE_KEY
 
    using the license key from your New Relic account.
-4. Edit the +config/newrelic_plugin.yml+ file generated in step 4.  Setup name/hostname/port/snmp_community for each F5 you wish to monitor.
+4. Edit the +config/newrelic_plugin.yml+ file generated in step 3.  Setup name/hostname/port/snmp_community for each F5 you wish to monitor.
 5. Execute
 
       f5_monitor run
@@ -96,6 +96,20 @@ To configure proxy settings, add to the newrelic_plugin.yml file:
 The F5 plugin can also be installed with {Chef}[http://www.getchef.com] and {Puppet}[http://puppetlabs.com]. For Chef and Puppet support see the New Relic plugin's {Chef Cookbook}[http://community.opscode.com/cookbooks/newrelic_plugins] and {Puppet Module}[https://forge.puppetlabs.com/newrelic/newrelic_plugins].
 
 Additional information on using Chef and Puppet with New Relic is available in New Relic's {documentation}[https://docs.newrelic.com/docs/plugins/plugin-installation-with-chef-and-puppet].
+
+== Logging Instructions
+
+Logging goes to stdout by default.
+
+There are 2 methods to increase logging to verbose level. Choose one of the following:
+
+1. Uncomment the following line from the +config/newrelic_plugin.yml+ file:
+
+      #verbose: 1
+
+2. Execute the plugin with the +-v+ or +--verbose+ option.
+
+      f5_monitor run -v
 
 == Developer Instructions
 


### PR DESCRIPTION
Fixed a typo in the installation instructions and added some logging instructions.