### PR TITLE
new cipher OIDs: ECDHE-RSA (keyx), AES-GCM (bulk)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+* 1.0.22
+  - Add Hardware ECDHE-RSA key exchange and AES-GCM bulk
+
 * 1.0.21
   - Add Hardware SYN Cookie generation / detection metrics
 

--- a/lib/newrelic_f5_plugin/agent.rb
+++ b/lib/newrelic_f5_plugin/agent.rb
@@ -4,7 +4,7 @@ require 'newrelic_plugin'
 require 'snmp'
 
 module NewRelic::F5Plugin
-  VERSION = '1.0.21'
+  VERSION = '1.0.22'
 
   # Register and run the agent
   def self.run

--- a/lib/newrelic_f5_plugin/global_ssl.rb
+++ b/lib/newrelic_f5_plugin/global_ssl.rb
@@ -37,11 +37,13 @@ module NewRelic
       OID_SYS_CLIENTSSL_STAT_DHRSA_KEYXCHG     = "#{OID_SYS_GLOBAL_CLIENT_SSL_STAT}.37.0"
       OID_SYS_CLIENTSSL_STAT_RSA_KEYXCHG       = "#{OID_SYS_GLOBAL_CLIENT_SSL_STAT}.40.0"
       OID_SYS_CLIENTSSL_STAT_EDHRSA_KEYXCHG    = "#{OID_SYS_GLOBAL_CLIENT_SSL_STAT}.51.0"
+      OID_SYS_CLIENTSSL_STAT_ECDHERSA_KEYXCHG  = "#{OID_SYS_GLOBAL_CLIENT_SSL_STAT}.63.0"
       # Server-side Key Exchanges
       OID_SYS_SERVERSSL_STAT_ADH_KEYXCHG       = "#{OID_SYS_GLOBAL_SERVER_SSL_STAT}.35.0"
       OID_SYS_SERVERSSL_STAT_DHRSA_KEYXCHG     = "#{OID_SYS_GLOBAL_SERVER_SSL_STAT}.37.0"
       OID_SYS_SERVERSSL_STAT_RSA_KEYXCHG       = "#{OID_SYS_GLOBAL_SERVER_SSL_STAT}.40.0"
       OID_SYS_SERVERSSL_STAT_EDHRSA_KEYXCHG    = "#{OID_SYS_GLOBAL_SERVER_SSL_STAT}.51.0"
+      OID_SYS_SERVERSSL_STAT_ECDHERSA_KEYXCHG  = "#{OID_SYS_GLOBAL_SERVER_SSL_STAT}.60.0"
 
       # Client-side Bulk
       OID_SYS_CLIENTSSL_STAT_NULL_BULK         = "#{OID_SYS_GLOBAL_CLIENT_SSL_STAT}.41.0"
@@ -50,6 +52,7 @@ module NewRelic
       OID_SYS_CLIENTSSL_STAT_IDEA_BULK         = "#{OID_SYS_GLOBAL_CLIENT_SSL_STAT}.44.0"
       OID_SYS_CLIENTSSL_STAT_RC2_BULK          = "#{OID_SYS_GLOBAL_CLIENT_SSL_STAT}.45.0"
       OID_SYS_CLIENTSSL_STAT_RC4_BULK          = "#{OID_SYS_GLOBAL_CLIENT_SSL_STAT}.46.0"
+      OID_SYS_CLIENTSSL_STAT_AESGCM_BULK       = "#{OID_SYS_GLOBAL_CLIENT_SSL_STAT}.70.0"
       # Server-side Bulk
       OID_SYS_SERVERSSL_STAT_NULL_BULK         = "#{OID_SYS_GLOBAL_SERVER_SSL_STAT}.41.0"
       OID_SYS_SERVERSSL_STAT_AES_BULK          = "#{OID_SYS_GLOBAL_SERVER_SSL_STAT}.42.0"
@@ -57,6 +60,7 @@ module NewRelic
       OID_SYS_SERVERSSL_STAT_IDEA_BULK         = "#{OID_SYS_GLOBAL_SERVER_SSL_STAT}.44.0"
       OID_SYS_SERVERSSL_STAT_RC2_BULK          = "#{OID_SYS_GLOBAL_SERVER_SSL_STAT}.45.0"
       OID_SYS_SERVERSSL_STAT_RC4_BULK          = "#{OID_SYS_GLOBAL_SERVER_SSL_STAT}.46.0"
+      OID_SYS_SERVERSSL_STAT_AESGCM_BULK       = "#{OID_SYS_GLOBAL_SERVER_SSL_STAT}.66.0"
 
       # Client-side Digests
       OID_SYS_CLIENTSSL_STAT_NULL_DIGEST       = "#{OID_SYS_GLOBAL_CLIENT_SSL_STAT}.47.0"
@@ -222,8 +226,8 @@ module NewRelic
 
         if snmp
 
-          res = gather_snmp_metrics_array([OID_SYS_CLIENTSSL_STAT_ADH_KEYXCHG, OID_SYS_CLIENTSSL_STAT_DHRSA_KEYXCHG, OID_SYS_CLIENTSSL_STAT_RSA_KEYXCHG, OID_SYS_CLIENTSSL_STAT_EDHRSA_KEYXCHG,
-                                           OID_SYS_SERVERSSL_STAT_ADH_KEYXCHG, OID_SYS_SERVERSSL_STAT_DHRSA_KEYXCHG, OID_SYS_SERVERSSL_STAT_RSA_KEYXCHG, OID_SYS_SERVERSSL_STAT_EDHRSA_KEYXCHG],
+          res = gather_snmp_metrics_array([OID_SYS_CLIENTSSL_STAT_ADH_KEYXCHG, OID_SYS_CLIENTSSL_STAT_DHRSA_KEYXCHG, OID_SYS_CLIENTSSL_STAT_RSA_KEYXCHG, OID_SYS_CLIENTSSL_STAT_EDHRSA_KEYXCHG, OID_SYS_CLIENTSSL_STAT_ECDHERSA_KEYXCHG,
+                                           OID_SYS_SERVERSSL_STAT_ADH_KEYXCHG, OID_SYS_SERVERSSL_STAT_DHRSA_KEYXCHG, OID_SYS_SERVERSSL_STAT_RSA_KEYXCHG, OID_SYS_SERVERSSL_STAT_EDHRSA_KEYXCHG, OID_SYS_SERVERSSL_STAT_ECDHERSA_KEYXCHG],
                                            snmp)
 
           # Bail out if we didn't get anything
@@ -231,14 +235,16 @@ module NewRelic
 
           vals = res.map { |i| i.to_i }
 
-          metrics["SSL/Global/KeyExchange/Client/Adh"]    = vals[0]
-          metrics["SSL/Global/KeyExchange/Client/DhRSA"]  = vals[1]
-          metrics["SSL/Global/KeyExchange/Client/RSA"]    = vals[2]
-          metrics["SSL/Global/KeyExchange/Client/EdhRsa"] = vals[3]
-          metrics["SSL/Global/KeyExchange/Server/Adh"]    = vals[4]
-          metrics["SSL/Global/KeyExchange/Server/DhRSA"]  = vals[5]
-          metrics["SSL/Global/KeyExchange/Server/RSA"]    = vals[6]
-          metrics["SSL/Global/KeyExchange/Server/EdhRsa"] = vals[7]
+          metrics["SSL/Global/KeyExchange/Client/Adh"]      = vals[0]
+          metrics["SSL/Global/KeyExchange/Client/DhRSA"]    = vals[1]
+          metrics["SSL/Global/KeyExchange/Client/RSA"]      = vals[2]
+          metrics["SSL/Global/KeyExchange/Client/EdhRsa"]   = vals[3]
+          metrics["SSL/Global/KeyExchange/Client/EcdheRsa"] = vals[4]
+          metrics["SSL/Global/KeyExchange/Server/Adh"]      = vals[5]
+          metrics["SSL/Global/KeyExchange/Server/DhRSA"]    = vals[6]
+          metrics["SSL/Global/KeyExchange/Server/RSA"]      = vals[7]
+          metrics["SSL/Global/KeyExchange/Server/EdhRsa"]   = vals[8]
+          metrics["SSL/Global/KeyExchange/Server/EcdheRsa"] = vals[9]
         end
 
         return metrics
@@ -256,8 +262,9 @@ module NewRelic
         if snmp
 
           res = gather_snmp_metrics_array([OID_SYS_CLIENTSSL_STAT_NULL_BULK, OID_SYS_CLIENTSSL_STAT_AES_BULK, OID_SYS_CLIENTSSL_STAT_DES_BULK, OID_SYS_CLIENTSSL_STAT_IDEA_BULK,
-                                           OID_SYS_CLIENTSSL_STAT_RC2_BULK, OID_SYS_CLIENTSSL_STAT_RC4_BULK, OID_SYS_SERVERSSL_STAT_NULL_BULK, OID_SYS_SERVERSSL_STAT_AES_BULK,
-                                           OID_SYS_SERVERSSL_STAT_DES_BULK, OID_SYS_SERVERSSL_STAT_IDEA_BULK, OID_SYS_SERVERSSL_STAT_RC2_BULK, OID_SYS_SERVERSSL_STAT_RC4_BULK],
+                                           OID_SYS_CLIENTSSL_STAT_RC2_BULK, OID_SYS_CLIENTSSL_STAT_RC4_BULK, OID_SYS_CLIENTSSL_STAT_AESGCM_BULK, OID_SYS_SERVERSSL_STAT_NULL_BULK,
+                                           OID_SYS_SERVERSSL_STAT_AES_BULK, OID_SYS_SERVERSSL_STAT_DES_BULK, OID_SYS_SERVERSSL_STAT_IDEA_BULK, OID_SYS_SERVERSSL_STAT_RC2_BULK,
+                                           OID_SYS_SERVERSSL_STAT_RC4_BULK, OID_SYS_SERVERSSL_STAT_AESGCM_BULK],
                                            snmp)
 
           # Bail out if we didn't get anything
@@ -265,19 +272,21 @@ module NewRelic
 
           vals = res.map { |i| i.to_i }
 
-          metrics["SSL/Global/Bulk/Client/Null"] = vals[0]
-          metrics["SSL/Global/Bulk/Client/AES"]  = vals[1]
-          metrics["SSL/Global/Bulk/Client/DES"]  = vals[2]
-          metrics["SSL/Global/Bulk/Client/IDEA"] = vals[3]
-          metrics["SSL/Global/Bulk/Client/RC2"]  = vals[4]
-          metrics["SSL/Global/Bulk/Client/RC4"]  = vals[5]
+          metrics["SSL/Global/Bulk/Client/Null"]   = vals[0]
+          metrics["SSL/Global/Bulk/Client/AES"]    = vals[1]
+          metrics["SSL/Global/Bulk/Client/DES"]    = vals[2]
+          metrics["SSL/Global/Bulk/Client/IDEA"]   = vals[3]
+          metrics["SSL/Global/Bulk/Client/RC2"]    = vals[4]
+          metrics["SSL/Global/Bulk/Client/RC4"]    = vals[5]
+          metrics["SSL/Global/Bulk/Client/AESGCM"] = vals[6]
 
-          metrics["SSL/Global/Bulk/Server/Null"] = vals[6]
-          metrics["SSL/Global/Bulk/Server/AES"]  = vals[7]
-          metrics["SSL/Global/Bulk/Server/DES"]  = vals[8]
-          metrics["SSL/Global/Bulk/Server/IDEA"] = vals[9]
-          metrics["SSL/Global/Bulk/Server/RC2"]  = vals[10]
-          metrics["SSL/Global/Bulk/Server/RC4"]  = vals[11]
+          metrics["SSL/Global/Bulk/Server/Null"]   = vals[7]
+          metrics["SSL/Global/Bulk/Server/AES"]    = vals[8]
+          metrics["SSL/Global/Bulk/Server/DES"]    = vals[9]
+          metrics["SSL/Global/Bulk/Server/IDEA"]   = vals[10]
+          metrics["SSL/Global/Bulk/Server/RC2"]    = vals[11]
+          metrics["SSL/Global/Bulk/Server/RC4"]    = vals[12]
+          metrics["SSL/Global/Bulk/Server/AESGCM"] = vals[13]
         end
 
         return metrics

--- a/newrelic_f5_plugin.gemspec
+++ b/newrelic_f5_plugin.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   ## If your rubyforge_project name is different, then edit it and comment out
   ## the sub! line in the Rakefile
   s.name              = 'newrelic_f5_plugin'
-  s.version           = '1.0.21'
-  s.date              = '2017-06-27'
+  s.version           = '1.0.22'
+  s.date              = '2019-06-18'
   s.rubyforge_project = 'newrelic_f5_plugin'
   s.licenses          = ['MIT']
 


### PR DESCRIPTION
* added OIDs for ECDHE-RSA key exchange and AES-GCM bulk, both client- and server-side
* adjusted arrays to include these new data sources
* bumped version to 1.0.22