### PR TITLE
Drop EOL'd property rubyforge_project

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,10 +23,6 @@ def date
   Date.today.to_s
 end
 
-def rubyforge_project
-  name
-end
-
 def gemspec_file
   "#{name}.gemspec"
 end
@@ -122,8 +118,6 @@ task :gemspec => :validate do
   replace_header(head, :name)
   replace_header(head, :version)
   replace_header(head, :date)
-  #comment this out if your rubyforge_project has a different name
-  replace_header(head, :rubyforge_project)
 
   # determine file list from git ls-files
   files = `git ls-files`.

--- a/newrelic_f5_plugin.gemspec
+++ b/newrelic_f5_plugin.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.name              = 'newrelic_f5_plugin'
   s.version           = '1.0.22'
   s.date              = '2019-06-20'
-  s.rubyforge_project = 'newrelic_f5_plugin'
   s.licenses          = ['MIT']
 
   ## Make sure your summary is short. The description may be as long


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.